### PR TITLE
Support NumPy 2 RAPIDS environments

### DIFF
--- a/dire_rapids/_compat.py
+++ b/dire_rapids/_compat.py
@@ -1,0 +1,48 @@
+"""Compatibility helpers for array/tensor interop."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def torch_tensor_to_numpy(tensor: Any, *, copy: bool = False) -> np.ndarray:
+    """Convert a PyTorch tensor to NumPy with a useful NumPy-bridge error.
+
+    PyTorch wheels compiled against NumPy 1.x cannot expose ``Tensor.numpy()``
+    when NumPy 2.x is installed. This commonly happens on GPU cloud images when
+    a system PyTorch package is mixed with a fresh RAPIDS/NumPy 2 environment.
+    The fix is to install PyTorch from a NumPy-2-compatible wheel in a clean
+    virtual environment, not to rebuild DiRe-RAPIDS.
+    """
+    try:
+        array = tensor.detach().cpu().numpy()
+    except RuntimeError as exc:
+        if "Numpy is not available" in str(exc):
+            raise RuntimeError(
+                "PyTorch cannot convert tensors to NumPy in this environment. "
+                "This usually means PyTorch was compiled against NumPy 1.x but "
+                "NumPy 2.x is installed. Use a clean virtual environment and "
+                "install a PyTorch build compiled against the active NumPy "
+                "major version."
+            ) from exc
+        raise
+    return array.copy() if copy else array
+
+
+def check_torch_numpy_bridge() -> None:
+    """Validate that PyTorch can convert CPU tensors to NumPy arrays."""
+    try:
+        import torch  # pylint: disable=import-outside-toplevel
+
+        _ = torch.arange(1).cpu().numpy()
+    except RuntimeError as exc:
+        if "Numpy is not available" in str(exc):
+            raise RuntimeError(
+                "PyTorch's NumPy bridge is unavailable. Avoid mixing a PyTorch "
+                "build compiled against NumPy 1.x with a NumPy 2 environment; "
+                "install PyTorch and NumPy together in a clean environment so "
+                "their ABI expectations match."
+            ) from exc
+        raise

--- a/dire_rapids/_compat.py
+++ b/dire_rapids/_compat.py
@@ -3,8 +3,24 @@
 from __future__ import annotations
 
 from typing import Any
+import warnings
 
 import numpy as np
+
+
+def install_pykeops_warning_filters() -> None:
+    """Suppress known third-party warnings emitted by PyKeOps internals."""
+    warnings.filterwarnings(
+        "ignore",
+        category=ResourceWarning,
+        module=r"keopscore\.config\.cuda",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message=r"`torch\.jit\.script_method` is deprecated.*",
+        category=DeprecationWarning,
+        module=r"torch\.jit\._script",
+    )
 
 
 def torch_tensor_to_numpy(tensor: Any, *, copy: bool = False) -> np.ndarray:
@@ -46,3 +62,11 @@ def check_torch_numpy_bridge() -> None:
                 "their ABI expectations match."
             ) from exc
         raise
+
+
+def import_pykeops_lazy_tensor():
+    """Import PyKeOps LazyTensor while containing known third-party warnings."""
+    install_pykeops_warning_filters()
+    from pykeops.torch import LazyTensor  # pylint: disable=import-outside-toplevel
+
+    return LazyTensor

--- a/dire_rapids/dire_cuvs.py
+++ b/dire_rapids/dire_cuvs.py
@@ -744,10 +744,10 @@ class DiReCuVS(DiRePyTorch):
             embedding_cp -= embedding_cp.mean(axis=0)
             embedding_cp /= embedding_cp.std(axis=0)
             
-            # Convert to PyTorch
-            # Use dlpack for zero-copy transfer from CuPy to PyTorch
-            from torch.utils.dlpack import from_dlpack  # pylint: disable=import-outside-toplevel
-            embedding_torch = from_dlpack(embedding_cp.toDlpack())
+            # Use DLPack for zero-copy transfer from CuPy to PyTorch.
+            # Modern CuPy exposes the Python DLPack protocol directly;
+            # ``toDlpack()`` is deprecated.
+            embedding_torch = torch.from_dlpack(embedding_cp)
             
             return embedding_torch.to(self.device)
         

--- a/dire_rapids/dire_pytorch.py
+++ b/dire_rapids/dire_pytorch.py
@@ -25,6 +25,8 @@ from scipy.optimize import curve_fit
 from sklearn.base import TransformerMixin
 from sklearn.decomposition import PCA
 
+from ._compat import torch_tensor_to_numpy
+
 # PyKeOps for efficient force computations
 try:
     from pykeops.torch import LazyTensor
@@ -662,11 +664,11 @@ class DiRePyTorch(TransformerMixin):
                 # For custom metrics, distances are already in metric space
                 # For Euclidean, convert from squared to actual distances
                 if self._metric_fn is None:
-                    knn_dists_np = torch.sqrt(knn_dists).cpu().numpy()
+                    knn_dists_np = torch_tensor_to_numpy(torch.sqrt(knn_dists))
                 else:
-                    knn_dists_np = knn_dists.cpu().numpy()
+                    knn_dists_np = torch_tensor_to_numpy(knn_dists)
                 chunk_indices, chunk_distances = _remove_self_from_knn(
-                    knn_indices.cpu().numpy(),
+                    torch_tensor_to_numpy(knn_indices),
                     knn_dists_np,
                     start_idx,
                     self.n_neighbors,
@@ -687,8 +689,8 @@ class DiRePyTorch(TransformerMixin):
                                                    dim=1, largest=False)
 
                 chunk_indices, chunk_distances = _remove_self_from_knn(
-                    knn_indices.cpu().numpy(),
-                    knn_dists.cpu().numpy(),
+                    torch_tensor_to_numpy(knn_indices),
+                    torch_tensor_to_numpy(knn_dists),
                     start_idx,
                     self.n_neighbors,
                 )
@@ -878,7 +880,7 @@ class DiRePyTorch(TransformerMixin):
                 # Use randomized SVD (pca_lowrank) — O(N*D*q) instead of full SVD,
                 # and avoids cusolver limits on very wide matrices (D >> N).
                 U, S, _ = torch.pca_lowrank(X_t, q=self.n_components)
-                embedding = (U * S).cpu().numpy()
+                embedding = torch_tensor_to_numpy(U * S)
                 del X_t, U, S
                 if self.device.type == 'cuda':
                     torch.cuda.empty_cache()
@@ -1146,7 +1148,7 @@ class DiRePyTorch(TransformerMixin):
         final_embedding = self._optimize_layout(initial_embedding)
 
         # Convert back to numpy and store
-        self._layout = final_embedding.cpu().numpy()
+        self._layout = torch_tensor_to_numpy(final_embedding)
 
         # Clear GPU memory
         if self.device.type == 'cuda':

--- a/dire_rapids/dire_pytorch.py
+++ b/dire_rapids/dire_pytorch.py
@@ -17,6 +17,7 @@ Performance characteristics:
 """
 
 import gc
+import importlib.util
 
 import numpy as np
 import torch
@@ -25,15 +26,11 @@ from scipy.optimize import curve_fit
 from sklearn.base import TransformerMixin
 from sklearn.decomposition import PCA
 
-from ._compat import torch_tensor_to_numpy
+from ._compat import import_pykeops_lazy_tensor, torch_tensor_to_numpy
 
-# PyKeOps for efficient force computations
-try:
-    from pykeops.torch import LazyTensor
-
-    PYKEOPS_AVAILABLE = True
-except ImportError:
-    PYKEOPS_AVAILABLE = False
+# PyKeOps is imported lazily to avoid import-time CUDA probing warnings.
+PYKEOPS_AVAILABLE = importlib.util.find_spec("pykeops") is not None
+if not PYKEOPS_AVAILABLE:
     logger.trace("PyKeOps not available. Install with: pip install pykeops")
 
 # cuVS for fast approximate k-NN at scale (optional RAPIDS dependency)
@@ -646,6 +643,8 @@ class DiRePyTorch(TransformerMixin):
 
             if use_pykeops:
                 # Use PyKeOps for LOW dimensional data
+                LazyTensor = import_pykeops_lazy_tensor()
+
                 # Ensure contiguity for PyKeOps
                 X_i = LazyTensor(X_chunk[:, None, :].contiguous())  # (chunk_size, 1, D)
                 X_j = LazyTensor(X_torch[None, :, :].contiguous())   # (1, N, D)

--- a/dire_rapids/dire_pytorch_memory_efficient.py
+++ b/dire_rapids/dire_pytorch_memory_efficient.py
@@ -11,20 +11,19 @@ This implementation inherits from DiRePyTorch and overrides specific methods for
 """
 
 import gc
+import importlib.util
 
 import numpy as np
 import torch
 from loguru import logger
 
 # Import base class and compiled kernels
+from ._compat import import_pykeops_lazy_tensor
 from .dire_pytorch import DiRePyTorch, _attraction_forces_compiled  # pylint: disable=cyclic-import
 
-# PyKeOps for efficient force computations
-try:
-    from pykeops.torch import LazyTensor
-    PYKEOPS_AVAILABLE = True
-except ImportError:
-    PYKEOPS_AVAILABLE = False
+# PyKeOps is imported lazily to avoid import-time CUDA probing warnings.
+PYKEOPS_AVAILABLE = importlib.util.find_spec("pykeops") is not None
+if not PYKEOPS_AVAILABLE:
     logger.trace("PyKeOps not available. Install with: pip install pykeops")
 
 
@@ -374,6 +373,7 @@ class DiRePyTorchMemoryEfficient(DiRePyTorch):
         if use_pykeops:
             self.logger.debug("Using PyKeOps LazyTensors for repulsion")
 
+            LazyTensor = import_pykeops_lazy_tensor()
             X_i = LazyTensor(positions[:, None, :].contiguous())  # (N, 1, D)
             X_j = LazyTensor(positions[None, :, :].contiguous())  # (1, N, D)
 

--- a/docs/lambda_labs.md
+++ b/docs/lambda_labs.md
@@ -1,0 +1,57 @@
+# Lambda Labs GPU Setup
+
+This note records a known-good setup for running DiRe-RAPIDS benchmarks on a
+Lambda Labs GPU instance. The same NumPy/PyTorch/RAPIDS compatibility rules in
+`docs/numpy2_rapids.md` apply here: use a clean virtual environment and avoid
+mixing Lambda image system packages with a fresh NumPy 2/RAPIDS stack.
+
+Verified instance class:
+
+- Lambda Labs `gpu_1x_a10`
+- NVIDIA A10, 23 GB GPU memory
+- Ubuntu 22.04
+- NVIDIA driver 580.105.08
+
+Setup:
+
+```bash
+python3 -m venv ~/dire-rapids-env
+source ~/dire-rapids-env/bin/activate
+python -m pip install --upgrade pip
+
+python -m pip install \
+  --extra-index-url https://pypi.nvidia.com \
+  --extra-index-url https://download.pytorch.org/whl/cu128 \
+  "dire-rapids[rapids,bench,viz,keops]"
+```
+
+For development from a clone:
+
+```bash
+git clone https://github.com/sashakolpakov/dire-rapids.git
+cd dire-rapids
+python -m pip install \
+  --extra-index-url https://pypi.nvidia.com \
+  --extra-index-url https://download.pytorch.org/whl/cu128 \
+  -e ".[rapids,bench,viz,keops]"
+```
+
+Verification:
+
+```bash
+python - <<'PY'
+import numpy, torch, cupy, cuml, cuvs, cudf
+print("numpy", numpy.__version__)
+print("torch", torch.__version__, torch.cuda.is_available())
+print("gpu", torch.cuda.get_device_name(0))
+print("cupy", cupy.__version__)
+print("cuml", cuml.__version__)
+print("cuvs", cuvs.__version__)
+print("cudf", cudf.__version__)
+print("torch numpy bridge", torch.arange(4, device="cuda").cpu().numpy())
+PY
+```
+
+If `Tensor.numpy()` fails, recreate the environment without
+`--system-site-packages` and install PyTorch from the PyTorch wheel index rather
+than using the image's system PyTorch package.

--- a/docs/numpy2_rapids.md
+++ b/docs/numpy2_rapids.md
@@ -1,0 +1,61 @@
+# NumPy 2 and RAPIDS Setup
+
+DiRe-RAPIDS supports NumPy 2 in environments where PyTorch and the RAPIDS
+packages are installed against a compatible NumPy ABI. The most common failure
+mode is mixing a system PyTorch package compiled against NumPy 1.x with a newer
+RAPIDS environment that installs NumPy 2.x. In that mixed state, PyTorch imports
+but `Tensor.numpy()` fails with `RuntimeError: Numpy is not available`.
+
+Use a clean virtual environment for RAPIDS work, and install PyTorch, NumPy, and
+RAPIDS together. Avoid `--system-site-packages` unless you know the system
+PyTorch build is compatible with the active NumPy major version.
+
+Example for CUDA 12 wheels:
+
+```bash
+python3 -m venv ~/dire-rapids-env
+source ~/dire-rapids-env/bin/activate
+python -m pip install --upgrade pip
+
+python -m pip install \
+  --extra-index-url https://pypi.nvidia.com \
+  --extra-index-url https://download.pytorch.org/whl/cu128 \
+  "dire-rapids[rapids,bench,viz,keops]"
+```
+
+For development from a clone:
+
+```bash
+git clone https://github.com/sashakolpakov/dire-rapids.git
+cd dire-rapids
+python -m pip install \
+  --extra-index-url https://pypi.nvidia.com \
+  --extra-index-url https://download.pytorch.org/whl/cu128 \
+  -e ".[rapids,bench,viz,keops]"
+```
+
+Verify the environment:
+
+```bash
+python - <<'PY'
+import numpy, torch, cupy, cuml, cuvs, cudf
+print("numpy", numpy.__version__)
+print("torch", torch.__version__, torch.cuda.is_available())
+print("gpu", torch.cuda.get_device_name(0))
+print("cupy", cupy.__version__)
+print("cuml", cuml.__version__)
+print("cuvs", cuvs.__version__)
+print("cudf", cudf.__version__)
+print("torch numpy bridge", torch.arange(4, device="cuda").cpu().numpy())
+PY
+```
+
+Expected package family for the `rapids` extra:
+
+- NumPy 2.x
+- PyTorch built against NumPy 2.x
+- RAPIDS/cuML/cuVS/cuDF 26.2 or later
+
+If the verification fails with `RuntimeError: Numpy is not available`, recreate
+the environment without system packages and install a PyTorch build compiled
+against the active NumPy major version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.21.0",
+    "numpy>=1.26.0",
     "torch>=2.0.0",
     "loguru>=0.6.0",
     "tqdm>=4.62.0",
@@ -66,10 +66,13 @@ cuda = [
     "cupy-cuda12x>=10.0.0",
 ]
 rapids = [
-    "cuml-cu12>=23.0.0",
-    "cuvs-cu12>=23.0.0",
-    "cudf-cu12>=23.0.0",
-    "cupy-cuda12x>=10.0.0",
+    "numpy>=2.0,<2.6",
+    "scipy>=1.13.0",
+    "torch>=2.11.0",
+    "cuml-cu12>=26.2.0,<27.0.0",
+    "cuvs-cu12>=26.2.0,<27.0.0",
+    "cudf-cu12>=26.2.0,<27.0.0",
+    "cupy-cuda12x>=14.0.0,<15.0.0",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/tests/test_numpy_bridge.py
+++ b/tests/test_numpy_bridge.py
@@ -1,0 +1,22 @@
+"""Environment checks for PyTorch/NumPy interoperability."""
+
+import numpy as np
+import pytest
+
+from dire_rapids._compat import check_torch_numpy_bridge, torch_tensor_to_numpy
+
+
+def test_torch_numpy_bridge_available():
+    pytest.importorskip("torch")
+
+    check_torch_numpy_bridge()
+
+
+def test_torch_tensor_to_numpy():
+    torch = pytest.importorskip("torch")
+
+    tensor = torch.arange(4)
+    array = torch_tensor_to_numpy(tensor)
+
+    assert isinstance(array, np.ndarray)
+    assert array.tolist() == [0, 1, 2, 3]


### PR DESCRIPTION
## Summary
- add a small PyTorch/NumPy bridge compatibility helper with actionable errors when PyTorch was compiled against the wrong NumPy major version
- tighten the RAPIDS extra around a NumPy 2 / RAPIDS 26.2 package family
- document generic NumPy 2 + RAPIDS setup and a Lambda Labs A10 setup note
- replace deprecated CuPy `toDlpack()` usage with the direct Python DLPack protocol

## Validation
Validated on a Lambda Labs `gpu_1x_a10` instance with NVIDIA A10, driver 580.105.08:

- clean venv with NumPy 2.2.6, PyTorch 2.11.0+cu128, cuML/cuVS/cuDF 26.02
- `pytest tests/test_numpy_bridge.py tests/test_cpu_basic.py -q`: 39 passed, 3 skipped
- smoke benchmark on 2,000 x 100 blobs ran DiRe, cuML UMAP, and cuML TSNE in one environment

## Notes
The key compatibility issue is not DiRe-specific: a system PyTorch build compiled against NumPy 1.x cannot use `Tensor.numpy()` under NumPy 2.x. The docs now recommend a clean environment and a PyTorch build compiled against the active NumPy major version.