### PR TITLE
Expose topology controls and optimize atlas Betti fallback

### DIFF
--- a/METRICS_README.md
+++ b/METRICS_README.md
@@ -14,11 +14,29 @@ print(f"DTW β₀: {results['topology']['metrics']['dtw_beta0']:.6f}")
 print(f"DTW β₁: {results['topology']['metrics']['dtw_beta1']:.6f}")
 ```
 
+Topology settings can be tuned through the public API while preserving the
+default protocol:
+
+```python
+results = evaluate_embedding(
+    data,
+    layout,
+    labels,
+    compute_topology=True,
+    topology_n_steps=50,
+    topology_k_neighbors=20,
+    topology_density_threshold=0.8,
+    topology_overlap_factor=1.5,
+    topology_metrics_only=True,
+)
+print(results["topology"]["protocol"])
+```
+
 ## Metrics
 
 1. **Distortion**: stress, neighborhood preservation
 2. **Context**: SVM/kNN classification accuracy
-3. **Topology**: DTW distances between Betti curves (β₀, β₁)
+3. **Topology**: DTW distances between Betti curves (β₀, β₁), plus protocol metadata
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,12 @@ X_embedded = reducer.fit_transform(X)
 
 ## Betti Curves / Topology
 
-The `betti_curve` module computes **filtered Betti curves** that track topological features across filtration thresholds. It builds an atlas complex from the kNN graph and computes Betti numbers (beta\_0 for connected components, beta\_1 for loops) via Hodge Laplacian eigenvalues.
+The `betti_curve` module computes **filtered Betti curves** that track topological features across filtration thresholds. It prefers `ripser` when available; otherwise it builds a kNN atlas complex and updates Betti numbers incrementally with union-find for beta\_0 and GF(2) bitset elimination for beta\_1.
 
 ```python
 from dire_rapids.betti_curve import compute_betti_curve
 
-# Automatic backend selection (GPU if CuPy available, else CPU/SciPy)
+# Automatic backend selection: ripser, then GPU atlas, then CPU atlas
 result = compute_betti_curve(X, k_neighbors=20, n_steps=50)
 
 print(result['filtration_values'])  # filtration thresholds
@@ -171,7 +171,7 @@ print(result['beta_0'])             # connected components at each step
 print(result['beta_1'])             # 1-cycles (loops) at each step
 ```
 
-Both CPU (SciPy sparse + ARPACK) and GPU (CuPy sparse + cuSOLVER) backends are available, with automatic fallback.
+The atlas fallback uses GPU kNN when cuVS/cuML is available, then performs the set-heavy atlas merge and incremental rank update on CPU.
 
 ## ReducerRunner Framework
 
@@ -208,7 +208,11 @@ print(f"Stress: {results['local']['stress']:.4f}")
 print(f"SVM accuracy: {results['context']['svm'][1]:.4f}")
 print(f"DTW beta_0: {results['topology']['metrics']['dtw_beta0']:.6f}")
 print(f"DTW beta_1: {results['topology']['metrics']['dtw_beta1']:.6f}")
+print(results['topology']['protocol'])
 ```
+
+Topology protocol parameters are exposed as `topology_n_steps`, `topology_k_neighbors`,
+`topology_density_threshold`, `topology_overlap_factor`, and `topology_metrics_only`.
 
 **Metrics:** distortion (stress, neighborhood preservation), context (SVM/kNN accuracy), topology (DTW distances between Betti curves). See [METRICS_README.md](METRICS_README.md) for details.
 

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -240,6 +240,8 @@ Comprehensive benchmarking notebook:
   - Context: SVM/kNN classification accuracy
   - Topology: DTW distances between Betti curves
 
+For financial market data, see `../examples/finance_analysis_notebook.ipynb`.
+
 ### ReducerRunner (in dire_rapids.utils)
 General-purpose framework for dimensionality reduction:
 - **ReducerRunner** class for running any sklearn-compatible reducer

--- a/dire_rapids/BETTI_ALGORITHM.md
+++ b/dire_rapids/BETTI_ALGORITHM.md
@@ -1,19 +1,20 @@
-# Fast Betti Curve Computation via Rank
+# Fast Betti Curve Computation via Incremental Atlas Filtration
 
 ## Overview
 
-The `betti_curve.py` module computes filtered Betti curves (beta_0, beta_1) for
-point cloud data using a kNN-based atlas complex. The key innovation is replacing
-expensive eigenvalue computation (scipy `eigsh`) with exact algebraic topology
-identities that reduce the problem to connected components and matrix rank.
+The `betti_curve.py` module computes filtered Betti curves (`beta_0`, `beta_1`)
+for point cloud data using a kNN-based atlas complex. The non-ripser fallback
+builds the atlas once, sorts simplex insertion events by filtration value, and
+updates Betti numbers incrementally.
 
 ## Mathematical Foundation
 
 For a simplicial complex with V vertices, E edges, T triangles, and boundary
 operators B1 (V x E) and B2 (E x T):
 
-**beta_0** (connected components) is computed via union-find in O(E * alpha(E)),
-essentially linear time.
+**beta_0** (connected components) is computed via union-find. As edges enter the
+filtration, each edge performs one `union(u, v)`. Path compression and union by
+rank make this effectively linear: O(E * alpha(V)).
 
 **beta_1** (independent loops) uses the Hodge decomposition identity:
 
@@ -23,32 +24,54 @@ where:
 - **rank(B1) = V - beta_0** (standard graph theory: the rank of the incidence
   matrix of a graph equals the number of vertices minus the number of connected
   components)
-- **rank(B2)** is computed via GPU-accelerated SVD (`torch.linalg.matrix_rank`)
+- **rank(B2)** is maintained incrementally over the field GF(2)
 
-This completely eliminates the need for eigenvalue computation of the Hodge
-Laplacian L1 = B1^T B1 + B2 B2^T, which was the performance bottleneck.
+This gives a field-valued Betti computation without floating-point rank
+thresholds.
 
 ## Implementation Details
 
-### Rank of B2
+### Incremental rank of B2 over GF(2)
 
 B2 is the boundary operator from 2-simplices (triangles) to 1-simplices (edges),
-an integer matrix with entries in {-1, 0, +1} and exactly 3 nonzero entries per
-column.
+with one column per triangle and one row per edge. Over GF(2), orientation signs
+disappear, so each triangle boundary is just a sparse bit vector with exactly
+three 1-bits: its three boundary edges.
 
-**Precision requirement: float64.** In float32, genuine zero singular values of
-B2 can be perturbed to ~1e-6, which may cross the data-dependent threshold used
-by `matrix_rank`. In float64, the perturbation is ~1e-15, safely below any
-reasonable threshold. This was discovered empirically: dense kNN complexes from
-Gaussian point clouds produce B2 matrices with genuine nonzero singular values as
-low as 0.24 (the initial assumption that all nonzero SVs >= 1 is false for
-general simplicial complexes).
+The implementation stores each column as a Python integer bitset. Adding a
+triangle means reducing that bitset against existing pivot columns:
 
-**Gram matrix optimization.** For large complexes (E * T > 5M elements), we
-compute the Gram matrix G = B2 * B2^T (size E x E) instead of materializing the
-full dense B2 (size E x T). The eigenvalues of G are the squared singular values
-of B2, and in float64 the default threshold (~1e-10) is far below the smallest
-genuine nonzero eigenvalue of G (~0.05), so this is safe.
+1. Take the highest set bit as the pivot row.
+2. If no pivot exists at that row, store this column and increment `rank(B2)`.
+3. If a pivot exists, XOR the column with the pivot and continue.
+4. If the column reduces to zero, it was dependent and does not change rank.
+
+Each triangle is processed once, when all three of its edges are active. This is
+the same sparse Gaussian-elimination idea used by persistent-homology reductions,
+but specialized to H1 of the atlas complex.
+
+Concretely, if the active edge list assigns indices `e0 -> 0`, `e1 -> 1`,
+`e2 -> 2`, ..., then a triangle with boundary edges `(e2, e5, e9)` is encoded as:
+
+    column = (1 << 2) | (1 << 5) | (1 << 9)
+
+The pivot table maps `highest_set_bit -> reduced_column`. For example, if
+`column.bit_length() - 1 == 9` and there is already a stored pivot at row 9, the
+new column is replaced by:
+
+    column ^= pivots[9]
+
+This is row cancellation over GF(2): `1 + 1 = 0`, so XOR clears the pivot bit and
+may toggle lower bits. The process repeats until either a new pivot row is found
+or the column becomes zero. Python integers make this compact: XOR and
+`bit_length()` operate on whole machine-word chunks internally rather than on
+Python lists of edge indices.
+
+Computing over GF(2) is deliberate: persistent homology is field-valued, GF(2) is
+the usual fast default, and it avoids expensive floating-point rank thresholds.
+For complexes with torsion, Betti numbers can depend on the chosen field; this
+fallback reports field-valued Betti numbers over GF(2). The
+`compute_betti_curve_cpu` path remains available as an eigsh-based reference.
 
 ### Backend Architecture
 
@@ -57,39 +80,36 @@ edge filtering):
 
 | Backend | kNN | Betti computation | Use case |
 |---------|-----|-------------------|----------|
-| `compute_betti_curve_fast` | sklearn (CPU) | union-find + GPU SVD rank | Default for CPU-only |
-| `compute_betti_curve_gpu` | cuVS/cuML (GPU) | union-find + GPU SVD rank | Default when GPU available |
+| `compute_betti_curve_fast` | sklearn (CPU) | incremental union-find + GF(2) bitset rank | Default for CPU-only |
+| `compute_betti_curve_gpu` | cuVS/cuML (GPU) | GPU kNN + incremental union-find/GF(2) bitset rank | Default when GPU available |
 | `compute_betti_curve_cpu` | sklearn (CPU) | scipy eigsh (shift-invert) | Reference implementation |
 
-The `compute_betti_curve` selector tries GPU first, then falls back to fast.
+The `compute_betti_curve` selector prefers ripser when installed, then tries the
+GPU atlas path, then falls back to the CPU atlas path.
 
 ### Performance
 
-The rank-based method is **not faster** than eigsh at typical sizes. Dense SVD
-for rank(B2) via the Gram matrix G = B2·B2ᵀ scales as O(E³) per filtration
-step, while eigsh exploits sparsity and only computes a handful of eigenvalues.
+The main operations are:
 
-On GH200 (480GB), with k=15, 10 filtration steps:
+- kNN construction;
+- atlas construction, roughly O(N * k^2) local neighbor-neighbor checks;
+- one pass over edge events and triangle events;
+- sparse GF(2) elimination on triangle boundary bitsets.
 
-| N   | CPU (eigsh) | Fast (rank) | Ratio    |
-|-----|-------------|-------------|----------|
-| 100 | ~0.2s       | ~1.7s       | eigsh 8x faster |
-| 200 | ~0.4s       | ~6.0s       | eigsh 15x faster |
-| 500 | ~2.5s       | ~31s        | eigsh 12x faster |
-
-The advantage of the rank-based method is **correctness**, not speed (see below).
+On a local Apple Silicon CPU, a noisy 3D circle with `k=15`, `n_steps=50` took
+about 0.34s at N=1000 and 1.40s at N=3000. Exact times vary by hardware and
+dataset geometry.
 
 ### Correctness
 
-The fast method is actually **more correct** than the eigsh reference at sparse
-filtration steps:
+The incremental atlas method is exact over GF(2):
 
 - **beta_0**: Union-find counts all connected components exactly, including
   isolated vertices. The eigsh method is capped at k=50 eigenvalues and cannot
   detect more than 50 components.
-- **beta_1**: The rank formula is exact (given sufficient numerical precision).
-  The eigsh method is iterative and can miss near-zero eigenvalues in
-  ill-conditioned Laplacians.
+- **beta_1**: The rank formula is exact over GF(2), and bitset elimination has
+  no floating-point tolerance.
 
-Small discrepancies (max 1-2) at transitional filtration steps are due to eigsh
-approximation errors, not the rank method.
+Small discrepancies with the eigsh reference can occur because eigsh is
+approximate and because eigsh over real coefficients and the atlas fallback over
+GF(2) are different coefficient-field protocols.

--- a/dire_rapids/betti_curve.py
+++ b/dire_rapids/betti_curve.py
@@ -3,9 +3,9 @@ Betti curve computation using filtered edge addition.
 
 Computes Betti numbers (β₀, β₁) at multiple filtration thresholds by:
 1. Building full atlas complex once with kNN graph
-2. Recording all edge distances
-3. Progressively adding edges by distance threshold
-4. Recomputing Laplacians and Betti numbers at each step
+2. Recording edge and triangle filtration values
+3. Progressively adding edges and triangles by threshold
+4. Updating β₀ with union-find and rank(B₂) over GF(2) incrementally
 
 Contains both CPU and GPU implementations with automatic backend selection.
 """
@@ -161,8 +161,98 @@ def _filter_at_threshold(filt_val, global_edges, edge_distances, triangle_edges)
     return active_edges, active_triangles, edge_to_idx
 
 
+class IncrementalF2Rank:
+    """Incremental sparse rank over GF(2), represented as Python integer bitsets."""
+
+    def __init__(self):
+        self.pivots = {}
+        self.rank = 0
+
+    def add(self, column):
+        """Add one boundary column. Return True if it increases rank."""
+        while column:
+            pivot = column.bit_length() - 1
+            existing = self.pivots.get(pivot)
+            if existing is None:
+                self.pivots[pivot] = column
+                self.rank += 1
+                return True
+            column ^= existing
+        return False
+
+
+def _compute_betti_curve_incremental(n, global_edges, edge_distances, triangle_edges,
+                                     filtration_values):
+    """
+    Compute atlas Betti curves in one monotone filtration pass.
+
+    Each simplex is added once. The pass uses union-find for beta_0 and maintains
+    rank(B2) over GF(2) with sparse bitsets.
+    Persistent homology is normally computed over a field; GF(2) avoids orientation
+    bookkeeping and is the standard choice for fast Vietoris-Rips computations.
+    """
+    edge_list = sorted(global_edges, key=lambda e: (edge_distances[e], e))
+    edge_to_idx = {edge: idx for idx, edge in enumerate(edge_list)}
+
+    triangle_events = []
+    for tri, e1, e2, e3 in triangle_edges:
+        if e1 in edge_to_idx and e2 in edge_to_idx and e3 in edge_to_idx:
+            filt_val = max(edge_distances[e1], edge_distances[e2], edge_distances[e3])
+            col = (
+                (1 << edge_to_idx[e1]) |
+                (1 << edge_to_idx[e2]) |
+                (1 << edge_to_idx[e3])
+            )
+            triangle_events.append((filt_val, tri, col))
+    triangle_events.sort(key=lambda item: (item[0], item[1]))
+
+    order = np.argsort(filtration_values)
+    beta_0_curve = np.empty(len(filtration_values), dtype=np.int64)
+    beta_1_curve = np.empty(len(filtration_values), dtype=np.int64)
+    n_edges_curve = np.empty(len(filtration_values), dtype=np.int64)
+    n_triangles_curve = np.empty(len(filtration_values), dtype=np.int64)
+
+    uf = UnionFind(n)
+    rank_b2 = IncrementalF2Rank()
+    edge_pos = 0
+    triangle_pos = 0
+    n_edges_active = 0
+    n_triangles_active = 0
+
+    for out_idx in order:
+        filt_val = filtration_values[out_idx]
+
+        while edge_pos < len(edge_list) and edge_distances[edge_list[edge_pos]] <= filt_val:
+            v0, v1 = edge_list[edge_pos]
+            uf.union(v0, v1)
+            edge_pos += 1
+            n_edges_active += 1
+
+        while triangle_pos < len(triangle_events) and triangle_events[triangle_pos][0] <= filt_val:
+            rank_b2.add(triangle_events[triangle_pos][2])
+            triangle_pos += 1
+            n_triangles_active += 1
+
+        beta_0 = uf.n_components
+        rank_b1 = n - beta_0
+        beta_1 = n_edges_active - rank_b1 - rank_b2.rank
+
+        beta_0_curve[out_idx] = beta_0
+        beta_1_curve[out_idx] = max(0, beta_1)
+        n_edges_curve[out_idx] = n_edges_active
+        n_triangles_curve[out_idx] = n_triangles_active
+
+    return {
+        'filtration_values': filtration_values,
+        'beta_0': beta_0_curve,
+        'beta_1': beta_1_curve,
+        'n_edges_active': n_edges_curve,
+        'n_triangles_active': n_triangles_curve
+    }
+
+
 # ---------------------------------------------------------------------------
-# Fast Betti computation via union-find (β₀) and matrix rank (β₁)
+# Betti computation helpers
 # ---------------------------------------------------------------------------
 
 class UnionFind:
@@ -457,20 +547,19 @@ def compute_betti_curve_cpu(data, k_neighbors=20, density_threshold=0.8,
 
 
 # ---------------------------------------------------------------------------
-# Fast implementation (union-find + rank, replaces eigsh)
+# Fast implementation (incremental atlas)
 # ---------------------------------------------------------------------------
 
 def compute_betti_curve_fast(data, k_neighbors=20, density_threshold=0.8,
                               overlap_factor=1.5, n_steps=50):
     """
-    Fast Betti curve computation using union-find (β₀) and matrix rank (β₁).
+    Fast Betti curve computation using an incremental atlas filtration.
 
-    Instead of computing eigenvalues of Hodge Laplacians via eigsh (the bottleneck
-    in compute_betti_curve_cpu), this uses algebraic topology identities:
+    Adds each edge and triangle once in filtration order:
       β₀ = connected components via union-find, O(E·α(E))
-      β₁ = E - rank(B1) - rank(B2) via Hodge decomposition
-      rank(B1) = V - β₀ (graph theory, free)
-      rank(B2) via GPU-accelerated SVD (torch.linalg.matrix_rank)
+      β₁ = E - rank(B1) - rank(B2)
+      rank(B1) = V - β₀
+      rank(B2) is maintained incrementally over GF(2) using sparse bitsets
 
     Parameters
     ----------
@@ -516,42 +605,13 @@ def compute_betti_curve_fast(data, k_neighbors=20, density_threshold=0.8,
     all_distances = np.array(list(edge_distances.values()))
     filtration_values = np.percentile(all_distances, np.linspace(100, 0, n_steps))
 
-    beta_0_curve = []
-    beta_1_curve = []
-    n_edges_curve = []
-    n_triangles_curve = []
-
-    for filt_val in filtration_values:
-        active_edges, active_triangles, edge_to_idx = _filter_at_threshold(
-            filt_val, global_edges, edge_distances, triangle_edges
-        )
-
-        n_edges_active = len(active_edges)
-        n_triangles_active = len(active_triangles)
-
-        if n_edges_active == 0:
-            beta_0, beta_1 = n, 0
-        else:
-            beta_0, beta_1 = _compute_betti_rank(
-                n, active_edges, active_triangles, edge_to_idx
-            )
-
-        beta_0_curve.append(beta_0)
-        beta_1_curve.append(beta_1)
-        n_edges_curve.append(n_edges_active)
-        n_triangles_curve.append(n_triangles_active)
-
-    return {
-        'filtration_values': filtration_values,
-        'beta_0': np.array(beta_0_curve),
-        'beta_1': np.array(beta_1_curve),
-        'n_edges_active': np.array(n_edges_curve),
-        'n_triangles_active': np.array(n_triangles_curve)
-    }
+    return _compute_betti_curve_incremental(
+        n, global_edges, edge_distances, triangle_edges, filtration_values
+    )
 
 
 # ---------------------------------------------------------------------------
-# GPU implementation (GPU kNN + rank-based Betti)
+# GPU implementation (GPU kNN + incremental atlas Betti)
 # ---------------------------------------------------------------------------
 
 def compute_betti_curve_gpu(data, k_neighbors=20, density_threshold=0.8,
@@ -559,9 +619,10 @@ def compute_betti_curve_gpu(data, k_neighbors=20, density_threshold=0.8,
     """
     GPU implementation of filtered Betti curve computation.
 
-    Uses GPU kNN (cuVS/cuML) for graph construction and rank-based Betti
-    computation (union-find for β₀, GPU SVD for β₁). Atlas building runs
-    on CPU (set operations are faster there).
+    Uses GPU kNN (cuVS/cuML) for graph construction, then the shared
+    incremental atlas computation (union-find for β₀ and GF(2) bitset
+    elimination for rank(B₂)). Atlas building runs on CPU because the set-heavy
+    merge step is faster and simpler there.
 
     Parameters
     ----------
@@ -631,38 +692,9 @@ def compute_betti_curve_gpu(data, k_neighbors=20, density_threshold=0.8,
     all_distances = np.array(list(edge_distances.values()))
     filtration_values = np.percentile(all_distances, np.linspace(100, 0, n_steps))
 
-    beta_0_curve = []
-    beta_1_curve = []
-    n_edges_curve = []
-    n_triangles_curve = []
-
-    for filt_val in filtration_values:
-        active_edges, active_triangles, edge_to_idx = _filter_at_threshold(
-            filt_val, global_edges, edge_distances, triangle_edges
-        )
-
-        n_edges_active = len(active_edges)
-        n_triangles_active = len(active_triangles)
-
-        if n_edges_active == 0:
-            beta_0, beta_1 = n, 0
-        else:
-            beta_0, beta_1 = _compute_betti_rank(
-                n, active_edges, active_triangles, edge_to_idx
-            )
-
-        beta_0_curve.append(beta_0)
-        beta_1_curve.append(beta_1)
-        n_edges_curve.append(n_edges_active)
-        n_triangles_curve.append(n_triangles_active)
-
-    return {
-        'filtration_values': filtration_values,
-        'beta_0': np.array(beta_0_curve),
-        'beta_1': np.array(beta_1_curve),
-        'n_edges_active': np.array(n_edges_curve),
-        'n_triangles_active': np.array(n_triangles_curve)
-    }
+    return _compute_betti_curve_incremental(
+        n, global_edges, edge_distances, triangle_edges, filtration_values
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -782,12 +814,13 @@ def compute_betti_curve(data, k_neighbors=20, density_threshold=0.8, overlap_fac
 
     Preference order (if available):
       ripser (if ``prefer_ripser`` and ``ripser`` is installed)
-      → GPU rank-based path (``compute_betti_curve_gpu``) if ``use_gpu``
-      → fast CPU rank-based path (``compute_betti_curve_fast``) as fallback.
+      → GPU kNN + incremental atlas path (``compute_betti_curve_gpu``) if
+        ``use_gpu``
+      → fast CPU incremental atlas path (``compute_betti_curve_fast``) as
+        fallback.
 
-    Ripser is the correct default: ~4000× faster than the eigsh path on
-    MNIST n=3000, and well-suited to large N; the older paths remain for
-    correctness cross-checks and for environments without ripser.
+    Ripser is the preferred default when available; the atlas paths provide a
+    dependency-light fallback for environments without ripser.
 
     Parameters
     ----------
@@ -803,10 +836,10 @@ def compute_betti_curve(data, k_neighbors=20, density_threshold=0.8, overlap_fac
     n_steps : int
         Number of filtration steps.
     use_gpu : bool
-        Whether to try the GPU rank-based path if ripser is not picked.
+        Whether to try the GPU kNN atlas path if ripser is not picked.
     prefer_ripser : bool
         Prefer ripser when available. Set to False to skip ripser and use
-        the rank-based backends only (e.g. for correctness comparison).
+        the atlas backends only (e.g. for correctness comparison).
 
     Returns
     -------

--- a/dire_rapids/metrics.py
+++ b/dire_rapids/metrics.py
@@ -1037,8 +1037,19 @@ def compute_global_metrics(data, layout, subsample_threshold=0.5, random_state=4
         'dtw_beta1': float(dtw_beta1)
     }
 
+    protocol = {
+        'subsample_threshold': subsample_threshold,
+        'random_state': random_state,
+        'n_steps': n_steps,
+        'k_neighbors': k_neighbors,
+        'density_threshold': density_threshold,
+        'overlap_factor': overlap_factor,
+        'use_gpu': use_gpu,
+        'metrics_only': metrics_only,
+    }
+
     if metrics_only:
-        return {'metrics': metrics, 'backend': 'atlas'}
+        return {'metrics': metrics, 'backend': 'atlas', 'protocol': protocol}
 
     # Include Betti curves if requested
     betti_curves = {
@@ -1054,7 +1065,12 @@ def compute_global_metrics(data, layout, subsample_threshold=0.5, random_state=4
         }
     }
 
-    return {'metrics': metrics, 'bettis': betti_curves, 'backend': 'atlas'}
+    return {
+        'metrics': metrics,
+        'bettis': betti_curves,
+        'backend': 'atlas',
+        'protocol': protocol,
+    }
 
 
 #
@@ -1064,7 +1080,10 @@ def compute_global_metrics(data, layout, subsample_threshold=0.5, random_state=4
 
 def evaluate_embedding(data, layout, labels=None, n_neighbors=16, subsample_threshold=0.5,
                       random_state=42, use_gpu=True, compute_distortion=True,
-                      compute_context=True, compute_topology=True, **kwargs):
+                      compute_context=True, compute_topology=True,
+                      topology_n_steps=100, topology_k_neighbors=20,
+                      topology_density_threshold=0.8, topology_overlap_factor=1.5,
+                      topology_metrics_only=True, **kwargs):
     """
     Comprehensive evaluation of a dimensionality reduction embedding.
 
@@ -1092,6 +1111,17 @@ def evaluate_embedding(data, layout, labels=None, n_neighbors=16, subsample_thre
         Whether to compute context metrics (default True)
     compute_topology : bool
         Whether to compute topological metrics (default True)
+    topology_n_steps : int
+        Number of filtration points for topology Betti curves (default 100)
+    topology_k_neighbors : int
+        Size of local neighborhood for topology atlas construction (default 20)
+    topology_density_threshold : float
+        Percentile threshold for topology edge inclusion (0-1, default 0.8)
+    topology_overlap_factor : float
+        Factor for expanding topology local neighborhoods (default 1.5)
+    topology_metrics_only : bool
+        If True, topology results include only metrics and protocol metadata.
+        If False, topology results also include Betti curves.
     **kwargs : dict
         Additional parameters for specific metrics
 
@@ -1130,7 +1160,13 @@ def evaluate_embedding(data, layout, labels=None, n_neighbors=16, subsample_thre
         print("Computing topological metrics using Betti curve comparison...")
         results['topology'] = compute_global_metrics(
             data, layout, subsample_threshold,
-            random_state, n_steps=100, use_gpu=use_gpu
+            random_state,
+            n_steps=topology_n_steps,
+            k_neighbors=topology_k_neighbors,
+            density_threshold=topology_density_threshold,
+            overlap_factor=topology_overlap_factor,
+            use_gpu=use_gpu,
+            metrics_only=topology_metrics_only,
         )
 
     return results

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,12 +161,17 @@ Evaluation metrics for dimensionality reduction quality:
    print(f"SVM accuracy: {results['context']['svm'][1]:.4f}")
    print(f"DTW β₀: {results['topology']['metrics']['dtw_beta0']:.6f}")
    print(f"DTW β₁: {results['topology']['metrics']['dtw_beta1']:.6f}")
+   print(results['topology']['protocol'])
+
+Topology protocol parameters are exposed as ``topology_n_steps``,
+``topology_k_neighbors``, ``topology_density_threshold``,
+``topology_overlap_factor``, and ``topology_metrics_only``.
 
 **Metrics:**
 
 * **Distortion**: stress, neighborhood preservation
 * **Context**: SVM/kNN classification accuracy
-* **Topology**: DTW distances between Betti curves (β₀, β₁) via kNN-atlas approach and Hodge Laplacians
+* **Topology**: DTW distances between Betti curves (β₀, β₁) via ripser when available, otherwise a kNN-atlas fallback with union-find and GF(2) bitset elimination
 
 See :doc:`api/dire_rapids.metrics` for full API reference.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,11 +59,12 @@ print(f"DTW β₀: {results['topology']['metrics']['dtw_beta0']:.6f}")
 print(f"DTW β₁: {results['topology']['metrics']['dtw_beta1']:.6f}")
 ```
 
-### 3. Financial Market Microstructure Analysis
+### 3. Financial Market Microstructure Analysis [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sashakolpakov/dire-rapids/blob/main/examples/finance_analysis_notebook.ipynb)
 
 A comprehensive demonstration of using DiRe's PyTorch backend for analyzing financial tick data and revealing market microstructure patterns through dimensionality reduction.
 
 **Files:**
+- `finance_analysis_notebook.ipynb` - Minimal Jupyter notebook for running the finance workflow
 - `finance_tick_embedding.py` - Simple minute-bar data analysis
 - `finance_tick_hierarchical.py` - Advanced tick-level data with hierarchical embedding  
 - `finance_analysis_notebook.py` - Interactive notebook-ready analysis tools
@@ -110,6 +111,8 @@ python finance_tick_embedding.py
 # Access the results
 embedding.head()
 ```
+
+For a ready-to-run notebook, open `finance_analysis_notebook.ipynb`.
 
 ### Interactive Analysis
 ```python

--- a/examples/finance_analysis_notebook.ipynb
+++ b/examples/finance_analysis_notebook.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiRe Financial Market Analysis\n",
+    "\n",
+    "This notebook is a small Jupyter entry point for the finance examples in this directory. It reuses `finance_analysis_notebook.py` so the notebook stays focused on running the workflow rather than duplicating the implementation.\n",
+    "\n",
+    "The examples fetch market data from Polygon.io and require `polygon-api-client`, `pandas`, and `plotly` in addition to DiRe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Run the notebook from the repository root or from the `examples/` directory. In Colab, uncomment the clone/install lines first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# In Colab, uncomment these lines:\n",
+    "# !git clone https://github.com/sashakolpakov/dire-rapids.git\n",
+    "# %cd dire-rapids\n",
+    "# !pip install -e .[viz] polygon-api-client\n",
+    "\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "cwd = Path.cwd()\n",
+    "if (cwd / \"examples\").is_dir():\n",
+    "    sys.path.insert(0, str(cwd / \"examples\"))\n",
+    "else:\n",
+    "    sys.path.insert(0, str(cwd))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from finance_analysis_notebook import (\n",
+    "    compare_tickers,\n",
+    "    create_animation,\n",
+    "    find_anomalies,\n",
+    "    quick_analysis,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Single Ticker Embedding\n",
+    "\n",
+    "Start with a modest trade limit while checking API access and runtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ticker = \"SPY\"\n",
+    "max_trades = 30000\n",
+    "\n",
+    "df = quick_analysis(ticker, max_trades=max_trades)\n",
+    "df.head() if df is not None else None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Anomaly View"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "anomalies = find_anomalies(df) if df is not None else None\n",
+    "anomalies.head() if anomalies is not None else None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optional Multi-Asset Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# comparison = compare_tickers([\"SPY\", \"QQQ\", \"IWM\"], max_trades=20000)\n",
+    "# comparison.head() if comparison is not None else None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optional Market Evolution Animation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# animation = create_animation(df, window_size=50) if df is not None else None"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_betti_atlas_incremental.py
+++ b/tests/test_betti_atlas_incremental.py
@@ -1,0 +1,48 @@
+"""Tests for the incremental atlas Betti backend."""
+
+import numpy as np
+
+from dire_rapids.betti_curve import compute_betti_curve_fast
+
+
+def test_incremental_atlas_full_complex_circle():
+    """n_steps=1 still returns the full atlas complex Betti numbers."""
+    n_samples = 120
+    theta = np.linspace(0, 2 * np.pi, n_samples, endpoint=False)
+    data = np.column_stack([np.cos(theta), np.sin(theta)]).astype(np.float32)
+
+    result = compute_betti_curve_fast(
+        data,
+        k_neighbors=15,
+        density_threshold=0.7,
+        overlap_factor=1.5,
+        n_steps=1,
+    )
+
+    assert int(result["beta_0"][0]) == 1
+    assert int(result["beta_1"][0]) == 1
+    assert int(result["n_edges_active"][0]) > 0
+    assert int(result["n_triangles_active"][0]) > 0
+
+
+def test_incremental_atlas_counts_are_monotone_with_filtration():
+    """Active simplex counts increase as thresholds increase."""
+    rng = np.random.default_rng(42)
+    data = rng.normal(size=(80, 4)).astype(np.float32)
+
+    result = compute_betti_curve_fast(
+        data,
+        k_neighbors=10,
+        density_threshold=0.7,
+        overlap_factor=1.3,
+        n_steps=12,
+    )
+
+    order = np.argsort(result["filtration_values"])
+    edges = result["n_edges_active"][order]
+    triangles = result["n_triangles_active"][order]
+
+    assert np.all(np.diff(edges) >= 0)
+    assert np.all(np.diff(triangles) >= 0)
+    assert np.all(result["beta_0"] >= 1)
+    assert np.all(result["beta_1"] >= 0)

--- a/tests/test_metrics_topology_config.py
+++ b/tests/test_metrics_topology_config.py
@@ -1,0 +1,132 @@
+"""Tests for topology parameter passthrough in evaluate_embedding."""
+
+import numpy as np
+
+from dire_rapids import metrics
+
+
+def test_evaluate_embedding_uses_topology_defaults(monkeypatch):
+    """Topology defaults stay compatible with the previous hardcoded values."""
+    captured = {}
+
+    def fake_compute_global_metrics(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {
+            "metrics": {"dtw_beta0": 0.0, "dtw_beta1": 0.0},
+            "backend": "atlas",
+            "protocol": kwargs,
+        }
+
+    monkeypatch.setattr(metrics, "compute_global_metrics", fake_compute_global_metrics)
+
+    data = np.zeros((8, 3), dtype=np.float32)
+    layout = np.zeros((8, 2), dtype=np.float32)
+
+    result = metrics.evaluate_embedding(
+        data,
+        layout,
+        compute_distortion=False,
+        compute_context=False,
+        compute_topology=True,
+        use_gpu=False,
+    )
+
+    assert "topology" in result
+    assert captured["kwargs"] == {
+        "n_steps": 100,
+        "k_neighbors": 20,
+        "density_threshold": 0.8,
+        "overlap_factor": 1.5,
+        "use_gpu": False,
+        "metrics_only": True,
+    }
+
+
+def test_evaluate_embedding_passes_custom_topology_parameters(monkeypatch):
+    """Public topology kwargs are forwarded to compute_global_metrics."""
+    captured = {}
+
+    def fake_compute_global_metrics(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {
+            "metrics": {"dtw_beta0": 1.0, "dtw_beta1": 2.0},
+            "backend": "atlas",
+            "protocol": kwargs,
+        }
+
+    monkeypatch.setattr(metrics, "compute_global_metrics", fake_compute_global_metrics)
+
+    data = np.zeros((8, 3), dtype=np.float32)
+    layout = np.zeros((8, 2), dtype=np.float32)
+
+    result = metrics.evaluate_embedding(
+        data,
+        layout,
+        compute_distortion=False,
+        compute_context=False,
+        compute_topology=True,
+        subsample_threshold=0.25,
+        random_state=7,
+        use_gpu=False,
+        topology_n_steps=25,
+        topology_k_neighbors=8,
+        topology_density_threshold=0.65,
+        topology_overlap_factor=2.0,
+        topology_metrics_only=False,
+    )
+
+    assert result["topology"]["metrics"] == {"dtw_beta0": 1.0, "dtw_beta1": 2.0}
+    assert captured["args"][2] == 0.25
+    assert captured["args"][3] == 7
+    assert captured["kwargs"] == {
+        "n_steps": 25,
+        "k_neighbors": 8,
+        "density_threshold": 0.65,
+        "overlap_factor": 2.0,
+        "use_gpu": False,
+        "metrics_only": False,
+    }
+
+
+def test_compute_global_metrics_returns_protocol(monkeypatch):
+    """Topology results include enough metadata to audit the protocol."""
+    from dire_rapids import betti_curve
+
+    def fake_compute_betti_curve(*args, **kwargs):
+        return {
+            "filtration_values": np.array([0.0, 1.0], dtype=np.float32),
+            "beta_0": np.array([2, 1], dtype=np.float32),
+            "beta_1": np.array([0, 1], dtype=np.float32),
+        }
+
+    monkeypatch.setattr(betti_curve, "compute_betti_curve", fake_compute_betti_curve)
+
+    data = np.zeros((8, 3), dtype=np.float32)
+    layout = np.zeros((8, 2), dtype=np.float32)
+
+    result = metrics.compute_global_metrics(
+        data,
+        layout,
+        subsample_threshold=1.0,
+        random_state=11,
+        n_steps=12,
+        k_neighbors=6,
+        density_threshold=0.7,
+        overlap_factor=1.25,
+        use_gpu=False,
+        metrics_only=True,
+    )
+
+    assert result["backend"] == "atlas"
+    assert result["protocol"] == {
+        "subsample_threshold": 1.0,
+        "random_state": 11,
+        "n_steps": 12,
+        "k_neighbors": 6,
+        "density_threshold": 0.7,
+        "overlap_factor": 1.25,
+        "use_gpu": False,
+        "metrics_only": True,
+    }


### PR DESCRIPTION
## Summary
- expose topology protocol parameters through evaluate_embedding and return protocol metadata
- replace the atlas fallback Betti curve loop with incremental union-find plus GF(2) bitset elimination
- add a compact finance analysis notebook and update README/docs references

## Tests
- HOME=/Users/sasha/dire-rapids/.home .venv/bin/python -m pytest tests/test_betti_atlas_incremental.py tests/test_metrics_topology_config.py -q
- HOME=/Users/sasha/dire-rapids/.home .venv/bin/python -m pytest tests/test_cpu_basic.py tests/test_reducer_runner.py -q
- jq empty examples/finance_analysis_notebook.ipynb
- git diff --check

Closes #2
Closes #8